### PR TITLE
npm node_modules error.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -76,8 +76,8 @@ var r = {
     // Check if exists
     fs.stat(compilerPath, function(err, stats) {
       if (!err && stats.isFile()) {
-        // Check if npm
-        if (__dirname.match(/\.npm/)) {
+        // Check if .npm(v0.x) node_modules(v1.x)
+        if (__dirname.match(/(\.npm|node_modules)/)) {
           var installPath = path.join(__dirname, '../../../compiler.jar');
           var is = fs.createReadStream(compilerPath)
           var os = fs.createWriteStream(installPath);


### PR DESCRIPTION
". npm" rather than "node_modules" to "npm" because it has changed, an error occurred.

readyjs -i ./deps/compiler/compiler.jar 
ERROR : Installing a compiler is available only with a NPM installation. Run `npm install ready`.
